### PR TITLE
Upgrade diarization to pyannote.audio 4 (speaker-diarization-community-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 .env
 models
+.hf_token

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Audio transcribing + diarization pipeline.
 
 ## AI/ML Models used
 
-- Whisper Large v3 Turbo (CTranslate 2 version `faster-whisper==1.1.1`)
-- Pyannote audio 3.3.1
+- Whisper Large v3 Turbo (CTranslate 2 version `faster-whisper==1.2.1`)
+- Pyannote `speaker-diarization-community-1` (`pyannote.audio>=4.0`)
 
 ## Usage
 
@@ -15,10 +15,9 @@ Audio transcribing + diarization pipeline.
 
 ## Deploy
 - Make sure you have [cog](https://cog.run) installed
-- Accept [pyannote/segmentation-3.0](https://hf.co/pyannote/segmentation-3.0) user conditions
-- Accept [pyannote/speaker-diarization-3.1](https://hf.co/pyannote/speaker-diarization-3.1) user conditions
+- Accept [pyannote/speaker-diarization-community-1](https://hf.co/pyannote/speaker-diarization-community-1) user conditions
 - Create HuggingFace token at [hf.co/settings/tokens](https://hf.co/settings/tokens).
-- Insert your own HuggingFace token in `predict.py` in the `setup` function
+- Provide your HuggingFace token either by adding a `.hf_token` file in the project root (gitignored), or by replacing the `YOUR HF TOKEN` placeholder in the `setup` function of `predict.py`
   - (Be careful not to commit this token!)
 - Run `cog build`
 - Run `cog predict -i input.wav`

--- a/cog.yaml
+++ b/cog.yaml
@@ -9,7 +9,6 @@ build:
   system_packages:
     - "ffmpeg"
     - "libmagic1"
-    - "cudnn9-cuda-12"
     # - "libgl1-mesa-glx"
     # - "libglib2.0-0"
 
@@ -20,8 +19,12 @@ build:
 
   # commands run after the environment is setup
   run:
-    - "echo env is ready!"
-    # - "echo another command if needed"
+    # faster-whisper/ctranslate2 needs cuDNN at runtime. torch ships it as a pip
+    # package (nvidia-cudnn-cu12); register those lib dirs so ctranslate2 finds them.
+    - "find /root/.pyenv -type d -path '*/site-packages/nvidia/*/lib' > /etc/ld.so.conf.d/zzz_nvidia.conf && ldconfig && echo 'registered nvidia/cudnn libs for ctranslate2'"
+    # hf-xet's download backend can fail behind some container networks; remove it so
+    # huggingface_hub falls back to classic HTTPS downloads.
+    - "pip uninstall -y hf-xet 2>/dev/null || python -m pip uninstall -y hf-xet 2>/dev/null || true; echo 'hf-xet removed (classic HF downloads)'"
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -7,8 +7,13 @@ import requests
 import time
 import torch
 import re
+from typing import Optional
 import pandas as pd
 import numpy as np
+
+# pyannote.audio 4 collects anonymous usage telemetry by default. Opt out before it
+# is imported below (the flag is read at import time).
+os.environ.setdefault("PYANNOTE_METRICS_ENABLED", "false")
 
 from cog import BasePredictor, BaseModel, Input, Path
 from faster_whisper import WhisperModel
@@ -33,21 +38,30 @@ class Predictor(BasePredictor):
             device="cuda",
             compute_type="float16",
         )
+        # Read the HF access token from a gitignored .hf_token file if present, so the
+        # token is baked into your private image without being committed; otherwise
+        # replace the placeholder below with your token.
+        _tok_path = os.path.join(os.path.dirname(__file__), ".hf_token")
+        _hf_token = (
+            open(_tok_path).read().strip()
+            if os.path.exists(_tok_path)
+            else "YOUR HF TOKEN"
+        )
         self.diarization_model = Pipeline.from_pretrained(
-            "pyannote/speaker-diarization-3.1",
-            use_auth_token="YOUR HF TOKEN",
+            "pyannote/speaker-diarization-community-1",
+            token=_hf_token,
         ).to(torch.device("cuda"))
 
     def predict(
         self,
-        file_string: str = Input(
+        file_string: Optional[str] = Input(
             description="Either provide: Base64 encoded audio file,", default=None
         ),
-        file_url: str = Input(
+        file_url: Optional[str] = Input(
             description="Or provide: A direct audio file URL", default=None
         ),
-        file: Path = Input(description="Or an audio file", default=None),
-        num_speakers: int = Input(
+        file: Optional[Path] = Input(description="Or an audio file", default=None),
+        num_speakers: Optional[int] = Input(
             description="Number of speakers, leave empty to autodetect.",
             ge=1,
             le=50,
@@ -57,11 +71,11 @@ class Predictor(BasePredictor):
             description="Translate the speech into English.",
             default=False,
         ),
-        language: str = Input(
+        language: Optional[str] = Input(
             description="Language of the spoken words as a language code like 'en'. Leave empty to auto detect language.",
             default=None,
         ),
-        prompt: str = Input(
+        prompt: Optional[str] = Input(
             description="Vocabulary: provide names, acronyms and loanwords in a list. Use punctuation for best accuracy.",
             default=None,
         ),
@@ -223,9 +237,12 @@ class Predictor(BasePredictor):
 
         print("Starting diarization")
         waveform, sample_rate = torchaudio.load(audio_file_wav)
+        diarization_kwargs = {}
+        if num_speakers is not None:
+            diarization_kwargs["num_speakers"] = num_speakers
         diarization = self.diarization_model(
             {"waveform": waveform, "sample_rate": sample_rate},
-            num_speakers=num_speakers,
+            **diarization_kwargs,
         )
 
         time_diraization_end = time.time()
@@ -237,7 +254,11 @@ class Predictor(BasePredictor):
 
         # Convert diarization list to DataFrame
         diarize_segments = []
-        diarization_list = list(diarization.itertracks(yield_label=True))
+        # pyannote.audio 4.x returns an output object whose Annotation lives on
+        # .speaker_diarization (3.x returned the Annotation directly).
+        diarization_list = list(
+            diarization.speaker_diarization.itertracks(yield_label=True)
+        )
 
         for turn, _, speaker in diarization_list:
             diarize_segments.append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
-torch==2.3.1
+torch>=2.8.0
 requests
-pyannote.audio>=3.3.1
-faster-whisper==1.1.1
+# Pin below hub 1.0: hub 1.x switched its HTTP backend from requests to httpx, which
+# raises RemoteProtocolError on Replicate's egress when a keep-alive connection is reset
+# mid-response (the small model-info call). requests/urllib3 retry on a fresh connection.
+# pyannote.audio 4 needs >=0.28.1; faster-whisper needs >=0.21 -- both satisfied.
+huggingface_hub>=0.28.1,<1.0
+pyannote.audio>=4.0
+faster-whisper==1.2.1
 ctranslate2==4.5.0
-torchvision>=0.15.2
-torchtext>=0.15.2
-numpy==1.26.4
+numpy
 tenacity
 pandas


### PR DESCRIPTION
## What

Upgrades the diarization stack from pyannote.audio 3.x (`speaker-diarization-3.1`) to **pyannote.audio 4.0** with the **`speaker-diarization-community-1`** pipeline, and refreshes the surrounding dependencies.

## Why

`community-1` is pyannote's successor pipeline shipped with pyannote.audio 4.0. Per the [model card](https://huggingface.co/pyannote/speaker-diarization-community-1) it lowers diarization error rate (DER) versus `speaker-diarization-3.1` on most public benchmarks, for example:

| Dataset | 3.1 | community-1 |
|---|---|---|
| AMI (SDM) | 22.7% | 19.9% |
| AliMeeting (ch.1) | 24.5% | 20.3% |
| MSDWild | 25.4% | 22.8% |
| DIHARD 3 | 21.4% | 20.2% |
| Ego4D | 51.2% | 46.8% |

It is marginally worse on REPERE (7.9% → 8.9%) and tied on VoxConverse, but lower DER on the large majority of datasets. It also adds exclusive speaker diarization (simpler reconciliation with transcript timestamps) and easy offline use.

## Changes

**`predict.py`**
- Load `pyannote/speaker-diarization-community-1` using the v4 `token=` argument.
- pyannote 4 returns a prediction object; read the annotation from `diarization.speaker_diarization.itertracks(...)`.
- Pass `num_speakers` only when provided.
- Type the optional inputs as `Optional[...]` so they stay optional under current Cog (Cog now treats `Input(default=None)` without `Optional` as a required field).
- Opt out of pyannote 4's anonymous usage telemetry (`PYANNOTE_METRICS_ENABLED=false`).
- Read the HF token from a gitignored `.hf_token` file if present (keeps the token out of the repo), otherwise the `YOUR HF TOKEN` placeholder.

**`requirements.txt`**
- `pyannote.audio>=4.0`, `faster-whisper==1.2.1`, `torch>=2.8.0`, unpinned `numpy` (pyannote 4 needs NumPy ≥2), and dropped unused `torchvision`/`torchtext`.
- Pin `huggingface_hub>=0.28.1,<1.0`. huggingface_hub 1.x switched its HTTP backend from `requests` to `httpx`, which raises `RemoteProtocolError: peer closed connection without sending complete message body` when a keep-alive connection to the Hub is reset mid-response on Replicate's network (the small model-info call). The `requests`/`urllib3` backend retries on a fresh connection. Both pyannote 4 (`>=0.28.1`) and faster-whisper (`>=0.21`) are satisfied by the pin.

**`cog.yaml`**
- Drop the `cudnn9-cuda-12` apt package (unavailable on the current CUDA base) and instead register torch's bundled `nvidia-cudnn-cu12` libraries via `ldconfig`, so ctranslate2 finds cuDNN at runtime.
- Remove `hf-xet` so huggingface_hub uses classic HTTPS downloads (the Xet backend can fail behind some container networks).

**`README.md`** — model list, deploy steps (a single gated repo to accept for community-1), and token instructions updated.

## Testing

Built with `cog push` and ran end-to-end on Replicate (GPU): setup completes and a full transcribe → diarize → merge prediction returns successfully on a multi-speaker recording.
