### PR TITLE
Feature: migrate to pyannote community-1 and latest deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 __pycache__
 .env
+.hf_token
 models

--- a/README.md
+++ b/README.md
@@ -2,27 +2,41 @@
 
 Audio transcribing + diarization pipeline.
 
-## AI/ML Models used
+## AI Models used
 
-- Whisper Large v3 Turbo (CTranslate 2 version `faster-whisper==1.1.1`)
-- Pyannote audio 3.3.1
+- Transcription: Faster Whisper Large v3 Turbo (`faster-whisper==1.2.1`)
+- Diarization: `pyannote/speaker-diarization-community-1` (`pyannote.audio==4.0.4`)
 
 ## Usage
 
-- Used at [Audiogest](https://audiogest.app) and [Spectropic](https://spectropic.ai)
+- Used at [Audiogest](https://audiogest.app)
 - Or try at [Replicate](https://replicate.com/thomasmol/whisper-diarization)
-- Or deploy yourself on [Replicate](https://replicate.com/) or any machine with a GPU 
+- Or use a similar version with better diarization at [pyannoteAI](https://www.pyannote.ai/)
+- Or build locally with [Cog](https://cog.run) and deploy on [Replicate](https://replicate.com/)
 
 ## Deploy
+
 - Make sure you have [cog](https://cog.run) installed
-- Accept [pyannote/segmentation-3.0](https://hf.co/pyannote/segmentation-3.0) user conditions
-- Accept [pyannote/speaker-diarization-3.1](https://hf.co/pyannote/speaker-diarization-3.1) user conditions
-- Create HuggingFace token at [hf.co/settings/tokens](https://hf.co/settings/tokens).
-- Insert your own HuggingFace token in `predict.py` in the `setup` function
-  - (Be careful not to commit this token!)
-- Run `cog build`
-- Run `cog predict -i input.wav`
-  - Or push to Replicate with `cog push r8.im/<username>/<name>`
+- Accept [pyannote/speaker-diarization-community-1](https://hf.co/pyannote/speaker-diarization-community-1) user conditions
+- Create a Hugging Face read token at [hf.co/settings/tokens](https://hf.co/settings/tokens) and write it to a local secret file: `.hf_token`
+- Then build:
+
+```sh
+cog build -t whisper-diarization:latest --secret id=HF_TOKEN,src=.hf_token
+```
+
+- Run:
+
+```sh
+cog run -i file=@input.wav
+```
+
+- Push to Replicate:
+
+```sh
+cog push r8.im/<username>/<name> --secret id=HF_TOKEN,src=.hf_token
+```
+
 - Please follow instructions on [cog.run](https://cog.run) if you run into issues
 
 ### Input
@@ -33,7 +47,7 @@ Audio transcribing + diarization pipeline.
 - `num_speakers: int`: Number of speakers. Leave empty to autodetect. Must be between 1 and 50.
 - `translate: bool`: Translate the speech into English.
 - `language: str`: Language of the spoken words as a language code like 'en'. Leave empty to auto detect language.
-- `prompt: str`: Vocabulary: provide names, acronyms, and loanwords in a list. Use punctuation for best accuracy. Also now used as 'hotwords' paramater in transcribing,
+- `prompt: str`: Vocabulary: provide names, acronyms, and loanwords in a list. Use punctuation for best accuracy.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cog run -i file=@input.wav
 - Push to Replicate:
 
 ```sh
-cog push r8.im/<username>/<name> --secret id=HF_TOKEN,src=.hf_token
+cog push r8.im/<username>/<name>
 ```
 
 - Please follow instructions on [cog.run](https://cog.run) if you run into issues

--- a/cog.yaml
+++ b/cog.yaml
@@ -9,19 +9,21 @@ build:
   system_packages:
     - "ffmpeg"
     - "libmagic1"
-    - "cudnn9-cuda-12"
     # - "libgl1-mesa-glx"
     # - "libglib2.0-0"
 
   # python version in the form '3.8' or '3.8.12'
-  python_version: "3.10"
+  python_version: "3.11"
 
   python_requirements: requirements.txt
 
   # commands run after the environment is setup
   run:
-    - "echo env is ready!"
-    # - "echo another command if needed"
-
-# predict.py defines how predictions are run on your model
-predict: "predict.py:Predictor"
+    - mkdir -p /models/whisper /models/diarization
+    - python -c "import faster_whisper; faster_whisper.download_model('large-v3-turbo', output_dir='/models/whisper/large-v3-turbo')"
+    - command: python -c "from huggingface_hub import snapshot_download; token=open('/run/secrets/HF_TOKEN').read().strip(); snapshot_download(repo_id='pyannote/speaker-diarization-community-1', local_dir='/models/diarization/pyannote--speaker-diarization-community-1', token=token)"
+      mounts:
+        - type: secret
+          id: HF_TOKEN
+          target: /run/secrets/HF_TOKEN
+run: "predict.py:Runner"

--- a/predict.py
+++ b/predict.py
@@ -73,6 +73,11 @@ class Runner(BaseRunner):
             default=None,
         ),
     ) -> Output:
+        if file_string == "":
+            file_string = None
+        if file_url == "":
+            file_url = None
+
         inputs = [file_string is not None, file_url is not None, file is not None]
         if sum(inputs) != 1:
             raise RuntimeError("Provide exactly one of file_string, file_url, or file")

--- a/predict.py
+++ b/predict.py
@@ -1,53 +1,60 @@
-# Prediction interface for Cog ⚙️
 import base64
-import datetime
-import subprocess
-import os
-import requests
-import time
-import torch
+import logging
 import re
-import pandas as pd
-import numpy as np
+import subprocess
+import tempfile
+import time
+from pathlib import Path as LocalPath
+from typing import Optional
 
-from cog import BasePredictor, BaseModel, Input, Path
-from faster_whisper import WhisperModel
-from pyannote.audio import Pipeline
+import numpy as np
+import pandas as pd
+import requests
+import torch
 import torchaudio
+from cog import BaseModel, BaseRunner, Input, Path
+from faster_whisper import WhisperModel
 from faster_whisper.vad import VadOptions
+from pyannote.audio import Pipeline
+
+WHISPER_MODEL_PATH = "/models/whisper/large-v3-turbo"
+DIARIZATION_MODEL_PATH = "/models/diarization/pyannote--speaker-diarization-community-1"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class Output(BaseModel):
     segments: list
-    language: str = None
-    num_speakers: int = None
+    language: Optional[str] = None
+    num_speakers: Optional[int] = None
 
 
-class Predictor(BasePredictor):
-
-    def setup(self):
-        """Load the model into memory to make running multiple predictions efficient"""
-        model_name = "large-v3-turbo"
+class Runner(BaseRunner):
+    def setup(self) -> None:
+        logger.info("Loading Whisper model from %s", WHISPER_MODEL_PATH)
         self.model = WhisperModel(
-            model_name,
+            model_size_or_path=WHISPER_MODEL_PATH,
             device="cuda",
             compute_type="float16",
         )
-        self.diarization_model = Pipeline.from_pretrained(
-            "pyannote/speaker-diarization-3.1",
-            use_auth_token="YOUR HF TOKEN",
-        ).to(torch.device("cuda"))
+        logger.info("Whisper model loaded")
+        logger.info("Loading diarization model from %s", DIARIZATION_MODEL_PATH)
+        self.diarization_model = Pipeline.from_pretrained(DIARIZATION_MODEL_PATH).to(
+            torch.device("cuda")
+        )
+        logger.info("Diarization model loaded")
 
-    def predict(
+    def run(
         self,
-        file_string: str = Input(
+        file_string: Optional[str] = Input(
             description="Either provide: Base64 encoded audio file,", default=None
         ),
-        file_url: str = Input(
+        file_url: Optional[str] = Input(
             description="Or provide: A direct audio file URL", default=None
         ),
-        file: Path = Input(description="Or an audio file", default=None),
-        num_speakers: int = Input(
+        file: Optional[Path] = Input(description="Or an audio file", default=None),
+        num_speakers: Optional[int] = Input(
             description="Number of speakers, leave empty to autodetect.",
             ge=1,
             le=50,
@@ -57,249 +64,246 @@ class Predictor(BasePredictor):
             description="Translate the speech into English.",
             default=False,
         ),
-        language: str = Input(
+        language: Optional[str] = Input(
             description="Language of the spoken words as a language code like 'en'. Leave empty to auto detect language.",
             default=None,
         ),
-        prompt: str = Input(
+        prompt: Optional[str] = Input(
             description="Vocabulary: provide names, acronyms and loanwords in a list. Use punctuation for best accuracy.",
             default=None,
         ),
     ) -> Output:
-        """Run a single prediction on the model"""
-        # Check if either filestring, filepath or file is provided, but only 1 of them
-        """ if sum([file_string is not None, file_url is not None, file is not None]) != 1:
-            raise RuntimeError("Provide either file_string, file or file_url") """
+        inputs = [file_string is not None, file_url is not None, file is not None]
+        if sum(inputs) != 1:
+            raise RuntimeError("Provide exactly one of file_string, file_url, or file")
 
-        try:
-            # Generate a temporary filename
-            temp_wav_filename = f"temp-{time.time_ns()}.wav"
+        start_time = time.time()
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = LocalPath(directory)
+            source_path = temp_dir / "source.audio"
+            wav_path = temp_dir / "audio.wav"
 
             if file is not None:
-                subprocess.run(
-                    [
-                        "ffmpeg",
-                        "-i",
-                        file,
-                        "-ar",
-                        "16000",
-                        "-ac",
-                        "1",
-                        "-c:a",
-                        "pcm_s16le",
-                        temp_wav_filename,
-                    ]
-                )
+                source_path = LocalPath(file)
+            if file_url is not None:
+                download_file(file_url, source_path)
+            if file_string is not None:
+                write_base64_file(file_string, source_path)
 
-            elif file_url is not None:
-                response = requests.get(file_url)
-                temp_audio_filename = f"temp-{time.time_ns()}.audio"
-                with open(temp_audio_filename, "wb") as file:
-                    file.write(response.content)
+            log_audio_metadata(source_path)
 
-                subprocess.run(
-                    [
-                        "ffmpeg",
-                        "-i",
-                        temp_audio_filename,
-                        "-ar",
-                        "16000",
-                        "-ac",
-                        "1",
-                        "-c:a",
-                        "pcm_s16le",
-                        temp_wav_filename,
-                    ]
-                )
-
-                if os.path.exists(temp_audio_filename):
-                    os.remove(temp_audio_filename)
-            elif file_string is not None:
-                audio_data = base64.b64decode(
-                    file_string.split(",")[1] if "," in file_string else file_string
-                )
-                temp_audio_filename = f"temp-{time.time_ns()}.audio"
-                with open(temp_audio_filename, "wb") as f:
-                    f.write(audio_data)
-
-                subprocess.run(
-                    [
-                        "ffmpeg",
-                        "-i",
-                        temp_audio_filename,
-                        "-ar",
-                        "16000",
-                        "-ac",
-                        "1",
-                        "-c:a",
-                        "pcm_s16le",
-                        temp_wav_filename,
-                    ]
-                )
-
-                if os.path.exists(temp_audio_filename):
-                    os.remove(temp_audio_filename)
+            normalize_start_time = time.time()
+            audio_duration = normalize_audio(source_path, wav_path)
+            logger.info("Audio normalized in %.2fs", time.time() - normalize_start_time)
+            logger.info("Audio duration: %.2fs", audio_duration)
 
             segments, detected_num_speakers, detected_language = self.speech_to_text(
-                temp_wav_filename,
+                str(wav_path),
                 num_speakers,
                 prompt,
                 language,
                 translate=translate,
             )
-
-            print(f"done with inference")
-            # Return the results as a JSON object
+            logger.info("Run completed in %.2fs", time.time() - start_time)
             return Output(
                 segments=segments,
                 language=detected_language,
                 num_speakers=detected_num_speakers,
             )
 
-        except Exception as e:
-            raise RuntimeError("Error Running inference with local model", e)
-
-        finally:
-            # Clean up
-            if os.path.exists(temp_wav_filename):
-                os.remove(temp_wav_filename)
-
-    def convert_time(self, secs, offset_seconds=0):
-        return datetime.timedelta(seconds=(round(secs) + offset_seconds))
-
     def speech_to_text(
         self,
-        audio_file_wav,
-        num_speakers=None,
-        prompt="",
-        language=None,
-        translate=False,
-    ):
-        time_start = time.time()
-
-        # Transcribe audio
-        print("Starting transcribing")
-        options = dict(
-            language=language,
-            beam_size=5,
-            vad_filter=True,
-            vad_parameters=VadOptions(
+        audio_file_wav: str,
+        num_speakers: Optional[int] = None,
+        prompt: Optional[str] = None,
+        language: Optional[str] = None,
+        translate: bool = False,
+    ) -> tuple[list[dict[str, object]], int, str]:
+        start_time = time.time()
+        gpu_type = get_gpu_type()
+        logger.info("GPU type: %s", gpu_type)
+        logger.info("Starting transcription")
+        options = {
+            "language": language,
+            "beam_size": 5,
+            "vad_filter": True,
+            "vad_parameters": VadOptions(
                 max_speech_duration_s=self.model.feature_extractor.chunk_length,
                 min_speech_duration_ms=100,
                 speech_pad_ms=100,
                 threshold=0.25,
                 neg_threshold=0.2,
             ),
-            word_timestamps=True,
-            initial_prompt=prompt,
-            language_detection_segments=1,
-            task="translate" if translate else "transcribe",
-        )
+            "word_timestamps": True,
+            "initial_prompt": prompt,
+            "language_detection_segments": 1,
+            "task": "translate" if translate else "transcribe",
+        }
         segments, transcript_info = self.model.transcribe(audio_file_wav, **options)
-        segments = list(segments)
-        segments = [
-            {
-                "avg_logprob": s.avg_logprob,
-                "start": float(s.start),
-                "end": float(s.end),
-                "text": s.text,
-                "words": [
-                    {
-                        "start": float(w.start),
-                        "end": float(w.end),
-                        "word": w.word,
-                        "probability": w.probability,
-                    }
-                    for w in s.words
-                ],
-            }
-            for s in segments
-        ]
-
-        time_transcribing_end = time.time()
-        print(
-            f"Finished with transcribing, took {time_transcribing_end - time_start:.5} seconds, {len(segments)} segments"
+        transcription = format_transcription_segments(list(segments))
+        transcribe_end_time = time.time()
+        logger.info(
+            "Transcription completed in %.2fs. Detected language: %s. Segments: %s",
+            transcribe_end_time - start_time,
+            transcript_info.language,
+            len(transcription),
         )
 
-        print("Starting diarization")
+        logger.info("Starting diarization")
         waveform, sample_rate = torchaudio.load(audio_file_wav)
         diarization = self.diarization_model(
             {"waveform": waveform, "sample_rate": sample_rate},
             num_speakers=num_speakers,
         )
-
-        time_diraization_end = time.time()
-        print(
-            f"Finished with diarization, took {time_diraization_end - time_transcribing_end:.5} seconds"
+        diarization_list = diarization.exclusive_speaker_diarization
+        diarize_end_time = time.time()
+        unique_speakers = {speaker for _, speaker in diarization_list}
+        logger.info(
+            "Diarization completed in %.2fs. Detected speakers: %s",
+            diarize_end_time - transcribe_end_time,
+            len(unique_speakers),
         )
 
-        print("Starting merging")
+        logger.info("Starting segment reconciliation")
+        final_segments = post_process_segments(transcription, diarization_list)
+        logger.info(
+            "Segment reconciliation completed in %.2fs. Final segments: %s",
+            time.time() - diarize_end_time,
+            len(final_segments),
+        )
+        return final_segments, len(unique_speakers), transcript_info.language
 
-        # Convert diarization list to DataFrame
-        diarize_segments = []
-        diarization_list = list(diarization.itertracks(yield_label=True))
 
-        for turn, _, speaker in diarization_list:
-            diarize_segments.append(
-                {"start": turn.start, "end": turn.end, "speaker": speaker}
+def download_file(url: str, path: LocalPath) -> None:
+    response = requests.get(url, timeout=120)
+    response.raise_for_status()
+    path.write_bytes(response.content)
+
+
+def write_base64_file(file_string: str, path: LocalPath) -> None:
+    encoded = file_string.split(",", 1)[1] if "," in file_string else file_string
+    path.write_bytes(base64.b64decode(encoded))
+
+
+def normalize_audio(input_path: LocalPath, wav_path: LocalPath) -> float:
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(input_path),
+            "-map",
+            "0:a:0",
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-c:a",
+            "pcm_s16le",
+            str(wav_path),
+        ],
+        check=True,
+    )
+    return get_duration(wav_path)
+
+
+def get_duration(path: LocalPath) -> float:
+    output = subprocess.check_output(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ]
+    )
+    return float(output.decode().strip())
+
+
+def log_audio_metadata(path: LocalPath) -> None:
+    try:
+        metadata = torchaudio.info(str(path))
+        logger.info(
+            "Audio metadata: sample_rate=%s, num_channels=%s, num_frames=%s, bits_per_sample=%s, encoding=%s",
+            metadata.sample_rate,
+            metadata.num_channels,
+            metadata.num_frames,
+            metadata.bits_per_sample,
+            metadata.encoding,
+        )
+    except Exception as error:
+        logger.info("Torchaudio could not read file metadata: %s", error)
+
+
+def format_transcription_segments(segments: list[object]) -> list[dict[str, object]]:
+    output_segments = []
+    for segment in segments:
+        output_segment = {
+            "avg_logprob": segment.avg_logprob,
+            "start": float(segment.start),
+            "end": float(segment.end),
+            "text": segment.text,
+            "words": [],
+        }
+        if segment.words is not None:
+            output_segment["words"] = [
+                {
+                    "start": float(word.start),
+                    "end": float(word.end),
+                    "word": word.word,
+                    "probability": word.probability,
+                }
+                for word in segment.words
+            ]
+        output_segments.append(output_segment)
+    return output_segments
+
+
+def post_process_segments(
+    segments: list[dict[str, object]], diarization_list: object
+) -> list[dict[str, object]]:
+    diarize_segments = []
+    for turn, speaker in diarization_list:
+        diarize_segments.append({"start": turn.start, "end": turn.end, "speaker": speaker})
+
+    diarize_df = pd.DataFrame(diarize_segments)
+    final_segments = []
+    for segment in segments:
+        diarize_df["intersection"] = np.minimum(
+            diarize_df["end"], segment["end"]
+        ) - np.maximum(diarize_df["start"], segment["start"])
+        dia_tmp = diarize_df[diarize_df["intersection"] > 0]
+        speaker = "UNKNOWN"
+        if len(dia_tmp) > 0:
+            speaker = (
+                dia_tmp.groupby("speaker")["intersection"]
+                .sum()
+                .sort_values(ascending=False)
+                .index[0]
             )
-        diarize_df = pd.DataFrame(diarize_segments)
-        unique_speakers = {speaker for _, _, speaker in diarization_list}
-        detected_num_speakers = len(unique_speakers)
 
-        # Process each segment and its words
-        final_segments = []
-        for segment in segments:
-            # Calculate intersection for segment-level speaker assignment
+        words_with_speakers = []
+        for word in segment["words"]:
             diarize_df["intersection"] = np.minimum(
-                diarize_df["end"], segment["end"]
-            ) - np.maximum(diarize_df["start"], segment["start"])
-            diarize_df["union"] = np.maximum(
-                diarize_df["end"], segment["end"]
-            ) - np.minimum(diarize_df["start"], segment["start"])
-
-            # Get speaker with maximum intersection
+                diarize_df["end"], word["end"]
+            ) - np.maximum(diarize_df["start"], word["start"])
             dia_tmp = diarize_df[diarize_df["intersection"] > 0]
+            word_speaker = speaker
             if len(dia_tmp) > 0:
-                speaker = (
+                word_speaker = (
                     dia_tmp.groupby("speaker")["intersection"]
                     .sum()
                     .sort_values(ascending=False)
                     .index[0]
                 )
-            else:
-                speaker = "UNKNOWN"
+            word["speaker"] = word_speaker
+            words_with_speakers.append(word)
 
-            # Process words if they exist
-            words_with_speakers = []
-            for word in segment["words"]:
-                # Calculate intersection for word-level speaker assignment
-                diarize_df["intersection"] = np.minimum(
-                    diarize_df["end"], word["end"]
-                ) - np.maximum(diarize_df["start"], word["start"])
-                diarize_df["union"] = np.maximum(
-                    diarize_df["end"], word["end"]
-                ) - np.minimum(diarize_df["start"], word["start"])
-
-                # Get speaker with maximum intersection
-                dia_tmp = diarize_df[diarize_df["intersection"] > 0]
-                if len(dia_tmp) > 0:
-                    word_speaker = (
-                        dia_tmp.groupby("speaker")["intersection"]
-                        .sum()
-                        .sort_values(ascending=False)
-                        .index[0]
-                    )
-                else:
-                    word_speaker = (
-                        speaker  # Fall back to segment speaker if no intersection
-                    )
-
-                word["speaker"] = word_speaker
-                words_with_speakers.append(word)
-
-            # Create new segment with speaker information
-            new_segment = {
+        final_segments.append(
+            {
                 "start": segment["start"],
                 "end": segment["end"],
                 "text": segment["text"],
@@ -307,55 +311,48 @@ class Predictor(BasePredictor):
                 "avg_logprob": segment["avg_logprob"],
                 "words": words_with_speakers,
             }
-            final_segments.append(new_segment)
-
-        # Smart grouping of segments
-        if len(final_segments) > 0:
-            grouped_segments = []
-            current_group = final_segments[0].copy()
-            sentence_end_pattern = r"[.!?]+"
-
-            for segment in final_segments[1:]:
-                time_gap = segment["start"] - current_group["end"]
-                current_duration = current_group["end"] - current_group["start"]
-
-                # Conditions for combining segments:
-                # 1. Same speaker
-                # 2. Time gap is reasonable (≤ 1 second)
-                # 3. Current group doesn't end with sentence-ending punctuation
-                # 4. Combined duration would not exceed 30 seconds
-                can_combine = (
-                    segment["speaker"] == current_group["speaker"]
-                    and time_gap <= 1.0
-                    and current_duration < 30.0
-                    and not re.search(sentence_end_pattern, current_group["text"][-1:])
-                )
-
-                if can_combine:
-                    # Merge segments
-                    current_group["end"] = segment["end"]
-                    current_group["text"] += " " + segment["text"]
-                    current_group["words"].extend(segment["words"])
-                else:
-                    # Start new group
-                    grouped_segments.append(current_group)
-                    current_group = segment.copy()
-
-            grouped_segments.append(current_group)
-            final_segments = grouped_segments
-
-        # Final cleanup of text
-        for segment in final_segments:
-            # Remove extra spaces
-            segment["text"] = re.sub(r"\s+", " ", segment["text"]).strip()
-            # Ensure proper spacing around punctuation
-            segment["text"] = re.sub(r"\s+([.,!?])", r"\1", segment["text"])
-            # Calculate segment duration
-            segment["duration"] = segment["end"] - segment["start"]
-
-        time_merging_end = time.time()
-        print(
-            f"Finished with merging, took {time_merging_end - time_diraization_end:.5} seconds"
         )
 
-        return final_segments, detected_num_speakers, transcript_info.language
+    if len(final_segments) == 0:
+        return final_segments
+
+    grouped_segments = []
+    current_group = final_segments[0].copy()
+    sentence_end_pattern = r"[.!?]+"
+
+    for segment in final_segments[1:]:
+        time_gap = segment["start"] - current_group["end"]
+        current_duration = current_group["end"] - current_group["start"]
+        can_combine = (
+            segment["speaker"] == current_group["speaker"]
+            and time_gap <= 1.0
+            and current_duration < 30.0
+            and not re.search(sentence_end_pattern, current_group["text"][-1:])
+        )
+        if can_combine:
+            current_group["end"] = segment["end"]
+            current_group["text"] += " " + segment["text"]
+            current_group["words"].extend(segment["words"])
+            continue
+
+        grouped_segments.append(current_group)
+        current_group = segment.copy()
+
+    grouped_segments.append(current_group)
+
+    for segment in grouped_segments:
+        segment["text"] = re.sub(r"\s+", " ", segment["text"]).strip()
+        segment["text"] = re.sub(r"\s+([.,!?])", r"\1", segment["text"])
+        segment["duration"] = segment["end"] - segment["start"]
+
+    return grouped_segments
+
+
+def get_gpu_type() -> str:
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"]
+        )
+        return output.decode().strip()
+    except Exception:
+        return "Unknown"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
-torch==2.3.1
+torch==2.8.0
 requests
-pyannote.audio>=3.3.1
-faster-whisper==1.1.1
-ctranslate2==4.5.0
-torchvision>=0.15.2
-torchtext>=0.15.2
-numpy==1.26.4
-tenacity
+pyannote-audio==4.0.4
+faster-whisper==1.2.1
+numpy
 pandas
+torchaudio==2.8.0


### PR DESCRIPTION
- Migrates Cog entrypoint from `predict.py:Predictor` to `predict.py:Runner` with `BaseRunner.run`, typed optional inputs, exactly-one input validation for `file_string`, `file_url`, or `file`, and structured `Output` fields.
- Preloads `large-v3-turbo` into `/models/whisper/large-v3-turbo` and `pyannote/speaker-diarization-community-1` into `/models/diarization/pyannote--speaker-diarization-community-1` during `cog.yaml` build using `HF_TOKEN` secret mounts.
- Updates runtime model loading to use local Whisper and pyannote paths, moves to Python 3.11, and replaces dependency set with `torch==2.8.0`, `torchaudio==2.8.0`, `pyannote-audio==4.0.4`, and `faster-whisper==1.2.1`.
- Reworks audio ingestion in `predict.py` to use `tempfile.TemporaryDirectory`, `requests.get(..., timeout=120)`, base64 decode helper, `ffmpeg` normalization with `check=True`, and `ffprobe` duration logging.
- Refactors transcription, diarization, speaker assignment, and segment grouping into helpers: `format_transcription_segments`, `post_process_segments`, `normalize_audio`, `get_duration`, `log_audio_metadata`, and `get_gpu_type`.
- Updates `README.md` deploy docs for `pyannote/speaker-diarization-community-1`, `.hf_token`, Cog secret builds, `cog run -i file=@input.wav`, and Replicate push with `HF_TOKEN` secret.
- Adds `.hf_token` to `.gitignore` so local Hugging Face token files stay untracked.
